### PR TITLE
wip: rename map_price to map_eth_price runtime error

### DIFF
--- a/erc20-market-cap/substreams.yaml
+++ b/erc20-market-cap/substreams.yaml
@@ -23,7 +23,6 @@ modules:
     kind: map
     initialBlock: 13000700
     inputs:
-      # - source: sf.ethereum.type.v2.Block
-      - map: erc20Price:map_price
+      - map: erc20Price:map_eth_price
     output:
       type: proto:messari.erc20_market_cap.Erc20MarketCaps

--- a/erc20-price/Makefile
+++ b/erc20-price/Makefile
@@ -8,7 +8,7 @@ build:
 
 .PHONY: example
 example:
-	substreams run -e api-dev.streamingfast.io:443 substreams.yaml map_price -s 13000000 -t +10
+	substreams run -e api-dev.streamingfast.io:443 substreams.yaml map_eth_price -s 13000000 -t +10
 
 .PHONY: pack
 pack:

--- a/erc20-price/src/lib.rs
+++ b/erc20-price/src/lib.rs
@@ -13,7 +13,7 @@ use substreams_helper::price;
 use substreams_helper::types::Network;
 
 #[substreams::handlers::map]
-fn map_price(block: eth::Block) -> Result<Erc20Prices, substreams::errors::Error> {
+fn map_eth_price(block: eth::Block) -> Result<Erc20Prices, substreams::errors::Error> {
     let mut erc20_tokens = HashSet::new();
     for log in block.logs() {
         if let Some(_) = abi::erc20::events::Transfer::match_and_decode(log) {

--- a/erc20-price/substreams.yaml
+++ b/erc20-price/substreams.yaml
@@ -18,7 +18,7 @@ binaries:
     file: ./target/wasm32-unknown-unknown/release/erc20_price_substreams.wasm
 
 modules:
-  - name: map_price
+  - name: map_eth_price
     kind: map
     initialBlock: 13000000
     inputs:


### PR DESCRIPTION
To reproduce:
1. cd erc20-price
2. make build && make example

Error
```
Error: rpc error: code = Internal desc = unexpected termination: process block failed: panic at block 13000000: runtime error: invalid memory address or nil pointer dereference
```