### PR TITLE
feature(erc20-holdings): tally correct balance; parse out erc20 token contracts from blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,9 +848,11 @@ name = "substreams-erc20-holdings"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bigdecimal",
  "ethabi",
  "getrandom",
  "hex-literal",
+ "num-bigint",
  "prost 0.11.0",
  "substreams",
  "substreams-common",

--- a/common/proto/common.proto
+++ b/common/proto/common.proto
@@ -10,3 +10,11 @@ message Transaction {
   string gas_price = 5; // string: BigInt, in wei
   uint64 gas_limit = 6;
 }
+
+message Address {
+  string address = 1;
+}
+
+message Addresses {
+  repeated Address items = 1;
+}

--- a/common/proto/erc20.proto
+++ b/common/proto/erc20.proto
@@ -20,10 +20,11 @@ message TransferEvents {
 message TransferEvent {
   string tx_hash = 1;
   uint32 log_index = 2;
-  string token_address = 3;
-  string from = 4;
-  string to = 5;
-  string amount = 6; // BigInt, in token's native amount
+  uint64 log_ordinal = 3;
+  string token_address = 4;
+  string from = 5;
+  string to = 6;
+  string amount = 7; // BigInt, in token's native amount
 }
 
 message TokenBalance {

--- a/erc20-holdings/Cargo.toml
+++ b/erc20-holdings/Cargo.toml
@@ -15,6 +15,8 @@ prost = "0.11.0"
 substreams = { workspace = true}
 substreams-ethereum = { workspace = true}
 substreams-helper = { path = "../substreams-helper" }
+num-bigint = "0.4"
+bigdecimal = "0.3"
 
 # Required so that ethabi > ethereum-types build correctly under wasm32-unknown-unknown
 getrandom = { version = "0.2", features = ["custom"] }

--- a/erc20-holdings/Makefile
+++ b/erc20-holdings/Makefile
@@ -8,4 +8,4 @@ build:
 
 .PHONY: run
 run:
-	substreams run -e mainnet.eth.streamingfast.io:443 substreams.yaml map_block_to_transfers,store_balance -s 14690152 -t +10
+	substreams run -e mainnet.eth.streamingfast.io:443 substreams.yaml map_block_to_transfers,store_balance -s 15657324 -t +200

--- a/erc20-holdings/Makefile
+++ b/erc20-holdings/Makefile
@@ -8,4 +8,4 @@ build:
 
 .PHONY: run
 run:
-	substreams run -e mainnet.eth.streamingfast.io:443 substreams.yaml map_block_to_transfers,store_balance -s 15657324 -t +200
+	substreams run -e mainnet.eth.streamingfast.io:443 substreams.yaml map_block_to_transfers,store_balance -s 14690152

--- a/erc20-holdings/Makefile
+++ b/erc20-holdings/Makefile
@@ -8,4 +8,4 @@ build:
 
 .PHONY: run
 run:
-	substreams run -e api-dev.streamingfast.io:443 substreams.yaml store_transfers -s 15244465 -t +1
+	substreams run -e mainnet.eth.streamingfast.io:443 substreams.yaml map_block_to_transfers,store_balance -s 14690152 -t +10

--- a/erc20-holdings/src/keyer.rs
+++ b/erc20-holdings/src/keyer.rs
@@ -1,0 +1,3 @@
+pub fn account_balance_key(account_address: &String) -> String {
+    format!("account_balance:{}", account_address)
+}

--- a/erc20-holdings/src/lib.rs
+++ b/erc20-holdings/src/lib.rs
@@ -6,15 +6,15 @@ pub mod pb;
 mod keyer;
 
 use num_bigint::BigInt;
-use std::str::FromStr;
 use std::ops::Neg;
+use std::str::FromStr;
 use substreams::{hex, log, proto, store, Hex};
 use substreams_ethereum::{pb::eth as pbeth, Event, NULL_ADDRESS};
 
 use substreams_helper::types::Address;
 
-use pb::erc20::v1 as erc20;
 use pb::common::v1 as common;
+use pb::erc20::v1 as erc20;
 
 fn code_len(call: &pbeth::v2::Call) -> usize {
     let mut len = 0;
@@ -48,9 +48,7 @@ fn map_block_to_erc20_contracts(
             }
 
             log::info!("Create {}, len {}", address, code_len(call));
-            erc20_contracts.items.push(common::Address {
-                address
-            });
+            erc20_contracts.items.push(common::Address { address });
         }
     }
 

--- a/erc20-holdings/src/pb.rs
+++ b/erc20-holdings/src/pb.rs
@@ -1,1 +1,2 @@
 pub mod erc20;
+pub mod common;

--- a/erc20-holdings/src/pb/common.rs
+++ b/erc20-holdings/src/pb/common.rs
@@ -1,0 +1,3 @@
+#[rustfmt::skip]
+#[path = "../../target/pb/messari.common.v1.rs"]
+pub mod v1;

--- a/erc20-holdings/substreams.yaml
+++ b/erc20-holdings/substreams.yaml
@@ -20,7 +20,7 @@ binaries:
 modules:
   - name: map_block_to_transfers
     kind: map
-    initialBlock: 14690152
+    initialBlock: 15657324
     inputs:
       - source: sf.ethereum.type.v2.Block
     output:

--- a/erc20-holdings/substreams.yaml
+++ b/erc20-holdings/substreams.yaml
@@ -9,6 +9,7 @@ imports:
 protobuf:
   files:
     - erc20.proto
+    - common.proto
   importPaths:
     - ../common/proto
 
@@ -18,9 +19,17 @@ binaries:
     file: ../target/wasm32-unknown-unknown/release/substreams_erc20_holdings.wasm
 
 modules:
+  - name: map_block_to_erc20_contracts
+    kind: map
+    initialBlock: 15657000
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:messari.common.v1.Addresses
+
   - name: map_block_to_transfers
     kind: map
-    initialBlock: 15657324
+    initialBlock: 14690152
     inputs:
       - source: sf.ethereum.type.v2.Block
     output:

--- a/erc20-holdings/substreams.yaml
+++ b/erc20-holdings/substreams.yaml
@@ -20,7 +20,7 @@ binaries:
 modules:
   - name: map_block_to_transfers
     kind: map
-    initialBlock: 1
+    initialBlock: 14690152
     inputs:
       - source: sf.ethereum.type.v2.Block
     output:
@@ -30,5 +30,12 @@ modules:
     kind: store
     updatePolicy: set
     valueType: proto:messari.erc20.v1.TransferEvents
+    inputs:
+      - map: map_block_to_transfers
+
+  - name: store_balance
+    kind: store
+    updatePolicy: add
+    valueType: bigint
     inputs:
       - map: map_block_to_transfers

--- a/uniswap-v2/src/pb.rs
+++ b/uniswap-v2/src/pb.rs
@@ -1,4 +1,4 @@
-pub mod common;
-pub mod dex_amm;
 pub mod uniswap;
 pub mod erc20;
+pub mod common;
+pub mod dex_amm;


### PR DESCRIPTION
Right now the `store_balance` module is able to tally per user balance across all blocks. Validated on USDD (`0c10bf8fcb7bf5412187a595ab97a3609160b5c6`) through its entire history, using a combination of Etherscan and this [Python notebook](https://colab.research.google.com/drive/10jM3oLX0jtvLZAEHfl8MxhXk1khGnfp0#scrollTo=1r73MrQTE5jI). It took me about 2 hours to process all of its 1M blocks, averaging around 160bps.

The `map_block_to_erc20_contracts` module is still a work-in-progress that'll parse out erc20 contracts, which we can use to tally balances across ALL erc20 tokens, instead of a specific one. It works as is but I expect a lot of edge cases to be found. SF has a reference implementation that handles more edge cases that I will use as a reference: https://github.com/streamingfast/substreams-playground/blob/master/modules/eth-token/src/lib.rs. The execution of this is very slow, somewhere between 2-5bps. I'm assuming this is due to the eth_calls we are making to verify a erc20 contract. Not sure if there are faster ways to do this.