### PR TITLE
fix(); erc20 holding; update config

### DIFF
--- a/erc20-holdings/.cargo/config.toml
+++ b/erc20-holdings/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "wasm32-unknown-unknown"

--- a/erc20-holdings/Makefile
+++ b/erc20-holdings/Makefile
@@ -6,4 +6,4 @@ build:
 
 .PHONY: run
 run:
-	substreams run -e mainnet.eth.streamingfast.io:443 substreams.yaml map_block_to_transfers,store_balance_usd -s 10606500
+	substreams run -e mainnet.eth.streamingfast.io:443 substreams.yaml map_block_to_erc20_contracts

--- a/erc20-holdings/Makefile
+++ b/erc20-holdings/Makefile
@@ -6,4 +6,4 @@ build:
 
 .PHONY: run
 run:
-	substreams run -e mainnet.eth.streamingfast.io:443 substreams.yaml map_block_to_erc20_contracts
+	substreams run -e mainnet.eth.streamingfast.io:443 substreams.yaml map_block_to_erc20_contracts -s 1

--- a/erc20-holdings/rust-toolchain.toml
+++ b/erc20-holdings/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.64.0"
+components = [ "rustfmt" ]
+targets = [ "wasm32-unknown-unknown" ]

--- a/erc20-holdings/src/lib.rs
+++ b/erc20-holdings/src/lib.rs
@@ -46,6 +46,7 @@ fn map_block_to_erc20_contracts(
         if call.call_type == pbeth::v2::CallType::Create as i32 {
             // skipping contracts that are too short to be an erc20 token
             if code_len(call) < 150 {
+                // contract byte code < 150 bytes
                 continue;
             }
 

--- a/erc20-holdings/src/lib.rs
+++ b/erc20-holdings/src/lib.rs
@@ -25,7 +25,7 @@ use substreams_ethereum::{pb::eth as pbeth, Event, NULL_ADDRESS};
 use substreams_helper::keyer::chainlink_asset_key;
 use substreams_helper::types::Address;
 
-fn code_len(call: &pbeth::v2::Call) -> usize {
+fn contract_bytecode_len(call: &pbeth::v2::Call) -> usize {
     let mut len = 0;
     for code_change in &call.code_changes {
         len += code_change.new_code.len()
@@ -45,8 +45,7 @@ fn map_block_to_erc20_contracts(
         let call = call_view.call;
         if call.call_type == pbeth::v2::CallType::Create as i32 {
             // skipping contracts that are too short to be an erc20 token
-            if code_len(call) < 150 {
-                // contract byte code < 150 bytes
+            if contract_bytecode_len(call) < 150 {
                 continue;
             }
 
@@ -57,7 +56,7 @@ fn map_block_to_erc20_contracts(
                 continue;
             }
 
-            log::info!("Create {}, len {}", address, code_len(call));
+            log::info!("Create {}, len {}", address, contract_bytecode_len(call));
             erc20_contracts.items.push(common::Address { address });
         }
     }

--- a/erc20-holdings/src/pb.rs
+++ b/erc20-holdings/src/pb.rs
@@ -37,3 +37,13 @@ pub mod erc20_price {
         pub use super::super::erc20_price_v1::*;
     }
 }
+
+#[rustfmt::skip]
+#[path = "../target/pb/messari.uniswap.v1.rs"]
+pub(in crate::pb) mod uniswap_v1;
+
+pub mod uniswap {
+    pub mod v1 {
+        pub use super::super::uniswap_v1::*;
+    }
+}

--- a/erc20-holdings/substreams.yaml
+++ b/erc20-holdings/substreams.yaml
@@ -22,7 +22,7 @@ binaries:
 modules:
   - name: map_block_to_erc20_contracts
     kind: map
-    initialBlock: 10606500
+    initialBlock: 1
     inputs:
       - source: sf.ethereum.type.v2.Block
     output:


### PR DESCRIPTION
Update the config to be the same as other substreams

- Adding `rust-toolchain.toml` is not necessary, but we have it in all the other substreams.
- I was running into issues because I didn't have the wasm target installed
- @robinbernon do you know why that uniswap section is being added when I build erc20-holdings? Should it be there now?