### PR TITLE
Added EventHandler and Storage utils to substreams-helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
  "anyhow",
  "ethabi",
  "num-bigint",
- "prost 0.11.6",
+ "prost 0.11.9",
  "substreams 0.5.6",
  "substreams-common",
  "substreams-ethereum",
@@ -207,7 +207,7 @@ dependencies = [
  "anyhow",
  "ethabi",
  "hex-literal",
- "prost 0.11.6",
+ "prost 0.11.9",
  "serde_json",
  "substreams 0.5.6",
  "substreams-common",
@@ -224,7 +224,7 @@ dependencies = [
  "ethabi",
  "hex-literal",
  "lazy_static",
- "prost 0.11.6",
+ "prost 0.11.9",
  "substreams 0.5.6",
  "substreams-common",
  "substreams-ethereum",
@@ -238,7 +238,7 @@ dependencies = [
  "anyhow",
  "ethabi",
  "hex-literal",
- "prost 0.11.6",
+ "prost 0.11.9",
  "substreams 0.5.6",
  "substreams-common",
  "substreams-ethereum",
@@ -253,7 +253,7 @@ dependencies = [
  "ethabi",
  "hex-literal",
  "num-bigint",
- "prost 0.11.6",
+ "prost 0.11.9",
  "substreams 0.5.6",
  "substreams-common",
  "substreams-ethereum",
@@ -269,7 +269,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "num-bigint",
- "prost 0.11.6",
+ "prost 0.11.9",
  "substreams 0.5.6",
  "substreams-common",
  "substreams-entity-change",
@@ -542,7 +542,7 @@ dependencies = [
  "chrono",
  "ethabi",
  "hex-literal",
- "prost 0.11.6",
+ "prost 0.11.9",
  "prost-types 0.11.1",
  "substreams 0.5.6",
  "substreams-common",
@@ -699,12 +699,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive 0.11.6",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.11.6",
+ "prost 0.11.9",
  "prost-types 0.11.1",
  "regex",
  "tempfile",
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -792,7 +792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
- "prost 0.11.6",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -1005,7 +1005,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "pad",
- "prost 0.11.6",
+ "prost 0.11.9",
  "prost-build 0.11.1",
  "prost-types 0.11.1",
  "substreams-macro 0.5.6",
@@ -1017,7 +1017,7 @@ dependencies = [
 name = "substreams-common"
 version = "0.1.0"
 dependencies = [
- "prost 0.11.6",
+ "prost 0.11.9",
  "regex",
  "substreams 0.5.6",
  "substreams-ethereum",
@@ -1031,7 +1031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c81fb0794efb438c5743c821ec76528c38878010c30d4a79d70799eac68837f6"
 dependencies = [
  "base64",
- "prost 0.11.6",
+ "prost 0.11.9",
  "prost-types 0.11.1",
  "substreams 0.5.6",
 ]
@@ -1044,7 +1044,7 @@ dependencies = [
  "ethabi",
  "getrandom",
  "hex-literal",
- "prost 0.11.6",
+ "prost 0.11.9",
  "substreams 0.5.6",
  "substreams-common",
  "substreams-ethereum",
@@ -1058,7 +1058,7 @@ dependencies = [
  "anyhow",
  "ethabi",
  "hex-literal",
- "prost 0.11.6",
+ "prost 0.11.9",
  "substreams 0.5.6",
  "substreams-common",
  "substreams-ethereum",
@@ -1104,7 +1104,7 @@ dependencies = [
  "ethabi",
  "getrandom",
  "num-bigint",
- "prost 0.11.6",
+ "prost 0.11.9",
  "prost-build 0.11.1",
  "prost-types 0.11.1",
  "substreams 0.5.6",
@@ -1136,7 +1136,8 @@ dependencies = [
  "hex-literal",
  "num-bigint",
  "pad",
- "prost 0.11.6",
+ "prost 0.11.9",
+ "prost-types 0.10.1",
  "substreams 0.5.6",
  "substreams-common",
  "substreams-ethereum",
@@ -1201,7 +1202,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "pad",
- "prost 0.11.6",
+ "prost 0.11.9",
  "substreams 0.5.6",
  "substreams-common",
  "substreams-ethereum",

--- a/substreams-helper/Cargo.toml
+++ b/substreams-helper/Cargo.toml
@@ -8,10 +8,11 @@ homepage = "https://messari.io/"
 repository = "https://github.com/messari/substreams/substreams-helper"
 
 [dependencies]
-ethabi = "17.0"
+ethabi = "17.2.0"
 hex = "0.4.3"
 hex-literal = "0.3.4"
-prost = "^0.11.0"
+prost = "0.11.8"
+prost-types = "0.10.1"
 num-bigint = "0.4"
 bigdecimal = "0.3"
 pad = "0.1"
@@ -21,6 +22,5 @@ substreams-ethereum = { workspace = true }
 thiserror = "1.0.37"
 
 [build-dependencies]
-anyhow = "1"
+anyhow = "1.0.69"
 substreams-common = { path = "../common" }
-

--- a/substreams-helper/src/common.rs
+++ b/substreams-helper/src/common.rs
@@ -1,0 +1,63 @@
+use ethabi::ethereum_types::Address;
+
+use substreams::store::{
+    StoreGet, StoreGetBigDecimal, StoreGetBigInt, StoreGetInt64, StoreGetProto, StoreGetRaw,
+    StoreGetString,
+};
+
+use crate::hex::Hexable;
+
+/// HasAddresser is a trait that a few functionalities in this crate depend on.
+/// Every time we need to filter something by address (events emmited by a set of addresses,
+/// storage changes occurring on certain contracts, etc) you'll likely need
+/// to provide a HasAddresser.
+///
+/// HasAddresser has been implemented already for all substreams::store's for convenience.
+/// So if you know a given store module contains the list of addresses you want to filter by
+/// you can pass it directly as a HasAddresser. In this case, the addresses need to be the store key
+/// hex encoded as a string including the leading 0x. The value of the store is ignored.
+pub trait HasAddresser {
+    fn has_address(&self, key: Address) -> bool;
+}
+
+impl HasAddresser for Vec<Address> {
+    fn has_address(&self, key: Address) -> bool {
+        self.contains(&key)
+    }
+}
+
+impl HasAddresser for StoreGetString {
+    fn has_address(&self, key: Address) -> bool {
+        self.get_last(key.to_hex()).is_some()
+    }
+}
+
+impl<T: Default + prost::Message> HasAddresser for StoreGetProto<T> {
+    fn has_address(&self, key: Address) -> bool {
+        self.get_last(key.to_hex()).is_some()
+    }
+}
+
+impl HasAddresser for StoreGetRaw {
+    fn has_address(&self, key: Address) -> bool {
+        self.get_last(key.to_hex()).is_some()
+    }
+}
+
+impl HasAddresser for StoreGetBigInt {
+    fn has_address(&self, key: Address) -> bool {
+        self.get_last(key.to_hex()).is_some()
+    }
+}
+
+impl HasAddresser for StoreGetBigDecimal {
+    fn has_address(&self, key: Address) -> bool {
+        self.get_last(key.to_hex()).is_some()
+    }
+}
+
+impl HasAddresser for StoreGetInt64 {
+    fn has_address(&self, key: Address) -> bool {
+        self.get_last(key.to_hex()).is_some()
+    }
+}

--- a/substreams-helper/src/event_handler.rs
+++ b/substreams-helper/src/event_handler.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+use ethabi::ethereum_types::Address;
+use substreams_ethereum::pb::eth::v2::{self as eth};
+use substreams_ethereum::Event;
+
+use crate::common::HasAddresser;
+
+/// Utility struct to easily filter events and assign them handlers.
+///
+/// Usage:
+/// ```
+/// let eh = EventHandler::new(&block);
+/// eh.filter_by_address(store); // This is optional, if omitted it will handle all events that match the type, independently of the emitting contract.
+/// eh.on::<Transfer, _>(&mut on_transfer);
+/// eh.on::<Approval, _>(&mut on_approval);
+/// eh.on::<Mint, _>(&mut on_mint);
+/// eh.on::<Burn, _>(&mut on_burn);
+/// eh.handle_events(); // this will run all handlers
+/// ```
+///
+/// You'll likely want to mutate some value from the handlers that is in the current scope.
+/// For that, make your handlers be closures, that close over the variable you want to mutate, and have the whole
+/// EventHandler block of code in its own scope (either by wrapping it in an aux function or by wrapping it in {...})
+///
+/// Like so:
+/// ```
+/// let mut balances : Vec<Balance> = vec![];
+/// {
+///     let mut on_transfer = |/*...*/| {
+///         // this handler modifies `balances`
+///         balances.push(some_balance);
+///     };
+///     let eh = EventHandler::new(&block);
+///     eh.on::<Transfer, _>(&mut on_transfer);
+///     eh.handle_events();
+/// }
+///
+/// // do whatever else with `balances` here.
+/// ```
+pub struct EventHandler<'a> {
+    block: &'a eth::Block,
+    handlers: HashMap<&'static str, Box<dyn FnMut(&eth::Log, &eth::TransactionTrace) + 'a>>,
+    addresses: Option<Box<dyn HasAddresser + 'a>>,
+}
+
+impl<'a> EventHandler<'a> {
+    pub fn new(block: &'a eth::Block) -> Self {
+        Self {
+            block,
+            handlers: HashMap::new(),
+            addresses: None,
+        }
+    }
+
+    /// Sets the HasAddresser as a filter for which events to handle.
+    /// Only one at a time can be set. Setting it twice will remove the first one.
+    /// Addresses found in the `HasAddresser` will be the ones we'll handle events from.
+    pub fn filter_by_address(&mut self, addresser: impl HasAddresser + 'a) {
+        self.addresses = Some(Box::new(addresser));
+    }
+
+    /// Registers a handler to be run on a given event. The handler should have the signature:
+    /// `|ev: SomeEvent, tx: &pbeth::v2::TransactionTrace, log: &pbeth::v2::Log|`.
+    /// You can only assign one handler to each Event type.
+    /// Handlers are keyed by the name of the event they are handling, so be careful to not assign handlers for 2 different events named equal.
+    pub fn on<E: Event, F>(&mut self, mut handler: F)
+    where
+        F: FnMut(E, &eth::TransactionTrace, &eth::Log) + 'a,
+    {
+        self.handlers.insert(
+            E::NAME,
+            Box::new(move |log: &eth::Log, tx: &eth::TransactionTrace| {
+                if let Some(event) = E::match_and_decode(log) {
+                    handler(event, tx, log);
+                }
+            }),
+        );
+    }
+
+    /// Will run all registered handlers for all events present on the block that match the given filters.
+    /// You'll likely want to run this just once.
+    pub fn handle_events(&mut self) {
+        for log in self.block.logs() {
+            if is_log_from_reverted_call(&log.log) {
+                continue;
+            }
+
+            if self.addresses.is_some()
+                && !&self
+                    .addresses
+                    .as_ref()
+                    .unwrap()
+                    .has_address(Address::from_slice(&log.log.address.as_slice()))
+            {
+                continue;
+            }
+
+            for handler in self.handlers.values_mut() {
+                handler(&log.log, log.receipt.transaction);
+            }
+        }
+    }
+}
+
+fn is_log_from_reverted_call(log: &eth::Log) -> bool {
+    log.block_index == 0
+}

--- a/substreams-helper/src/hex.rs
+++ b/substreams-helper/src/hex.rs
@@ -1,0 +1,20 @@
+use ethabi::ethereum_types::Address;
+use substreams::Hex;
+
+pub trait Hexable {
+    fn to_hex(&self) -> String;
+}
+
+impl Hexable for Vec<u8> {
+    fn to_hex(self: &Self) -> String {
+        let mut str = Hex::encode(self);
+        str.insert_str(0, "0x");
+        str
+    }
+}
+
+impl Hexable for Address {
+    fn to_hex(self: &Self) -> String {
+        self.as_bytes().to_vec().to_hex()
+    }
+}

--- a/substreams-helper/src/lib.rs
+++ b/substreams-helper/src/lib.rs
@@ -1,9 +1,13 @@
 pub mod abi;
 pub mod block;
+pub mod common;
 pub mod convert;
 pub mod erc20;
+pub mod event_handler;
+pub mod hex;
 pub mod keyer;
 pub mod math;
 pub mod price;
+pub mod storage;
 pub mod types;
 pub mod utils;

--- a/substreams-helper/src/storage.rs
+++ b/substreams-helper/src/storage.rs
@@ -1,0 +1,228 @@
+use ethabi::ethereum_types::Address;
+
+use substreams::scalar::BigInt;
+use substreams_ethereum::pb::eth as pbeth;
+use tiny_keccak::{Hasher, Keccak};
+
+use crate::common::HasAddresser;
+
+/// Retrieves all storage changes in a block for all contracts under HasAddresser.
+pub fn get_storage_changes_for_addresses(
+    store: &impl HasAddresser,
+    block: &pbeth::v2::Block,
+) -> Vec<pbeth::v2::StorageChange> {
+    let mut changes: Vec<pbeth::v2::StorageChange> = vec![];
+    for call in block.calls() {
+        for change in &call.call.storage_changes {
+            if !store.has_address(Address::from_slice(change.address.as_slice())) {
+                continue;
+            }
+            changes.push(change.to_owned());
+        }
+    }
+    changes
+}
+
+/// Utility class to play around with Uint256 storage values.
+pub struct Uint256 {
+    pub slot: BigInt,
+}
+
+impl Uint256 {
+    pub fn storage_key(&self) -> Vec<u8> {
+        ethabi::encode(&[self.slot.abi_token()])
+    }
+}
+
+/// Utility class to play around with Mapping storage values.
+pub struct Mapping {
+    pub slot: BigInt,
+}
+
+impl Mapping {
+    /// For a given key, will calculate the abi encoded keccak preimage.
+    /// Hashing the preimage will return the storage key where a given value from the mapping is.
+    pub fn preimage(&self, key: &impl ABIEncodeable) -> Vec<u8> {
+        ethabi::encode(&[key.abi_token(), self.slot.abi_token()])
+    }
+
+    /// Returns the EVM storage key where the given mapping key is stored.
+    pub fn storage_key(&self, key: &impl ABIEncodeable) -> Vec<u8> {
+        let preimage = self.preimage(key);
+        let mut keccak = Keccak::v256();
+        let mut output = [0u8; 32];
+        keccak.update(preimage.as_slice());
+        keccak.finalize(&mut output);
+        return output.to_vec();
+    }
+
+    /// Given a keccak256 preimage, determines what is the key of the mapping associated to it.
+    /// Returns None if the format is wrong or there isn't a match.
+    pub fn key_from_preimage<T: ABIEncodeable>(&self, preimage: Vec<u8>) -> Option<T> {
+        let slot = ethabi::encode(&[self.slot.abi_token()]);
+        if !preimage.ends_with(slot.as_slice()) {
+            return None;
+        }
+
+        let key = preimage.split_at(preimage.len() - slot.len()).0;
+        let t = T::abi_decode(key.to_vec());
+        if t.is_err() {
+            return None;
+        }
+        Some(t.unwrap())
+    }
+}
+
+pub trait ABIEncodeable {
+    fn abi_token(&self) -> ethabi::Token;
+    fn abi_decode(abi_encoded: Vec<u8>) -> Result<Self, ethabi::Error>
+    where
+        Self: Sized;
+}
+
+impl ABIEncodeable for BigInt {
+    fn abi_token(&self) -> ethabi::Token {
+        ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+            self.to_bytes_be().1.as_slice(),
+        ))
+    }
+
+    fn abi_decode(abi_encoded: Vec<u8>) -> Result<Self, ethabi::Error> {
+        let mut bytes: [u8; 32] = [0; 32];
+        let first = ethabi::Uint::from_big_endian(abi_encoded.as_slice());
+        first.to_big_endian(&mut bytes);
+        Ok(BigInt::from_unsigned_bytes_be(&bytes))
+    }
+}
+
+impl ABIEncodeable for Address {
+    fn abi_token(&self) -> ethabi::Token {
+        ethabi::Token::Address(self.clone())
+    }
+
+    fn abi_decode(abi_encoded: Vec<u8>) -> Result<Self, ethabi::Error> {
+        let decoded = ethabi::decode(&[ethabi::ParamType::Address], abi_encoded.as_slice())?;
+        Ok(decoded[0].to_owned().into_address().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod abi_encodeable {
+        use std::str::FromStr;
+        use substreams::scalar::BigInt;
+
+        use super::super::*;
+        use crate::hex::Hexable;
+
+        #[test]
+        fn test_abi_token() {
+            struct TT<'a> {
+                name: &'static str,
+                abi_encodeable: Box<dyn ABIEncodeable + 'a>,
+                encoded: &'static str,
+            }
+
+            let tests: Vec<TT> = vec![
+                TT {
+                    name: "Address impl",
+                    abi_encodeable: Box::new(
+                        Address::from_str("0xca0e8f557ea98f950029a41d74f16dd76648b1f1").unwrap(),
+                    ),
+                    encoded: "0x000000000000000000000000ca0e8f557ea98f950029a41d74f16dd76648b1f1",
+                },
+                TT {
+                    name: "BigInt impl",
+                    abi_encodeable: Box::new(BigInt::from(54)),
+                    encoded: "0x0000000000000000000000000000000000000000000000000000000000000036",
+                },
+            ];
+
+            for tt in tests {
+                assert_eq!(
+                    ethabi::encode(&[tt.abi_encodeable.abi_token()]).to_hex(),
+                    tt.encoded,
+                    "Failed at test with name: {}",
+                    tt.name,
+                );
+            }
+        }
+
+        #[test]
+        fn test_abi_decode_big_int() {
+            {
+                let encoded =
+                    hex::decode("0000000000000000000000000000000000000000000000000000000000000036")
+                        .unwrap();
+                assert_eq!(
+                    BigInt::abi_decode(encoded).unwrap(),
+                    BigInt::from(54),
+                    "Decode Normal Number"
+                );
+            }
+
+            {
+                let encoded =
+                    hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+                        .unwrap();
+                assert_eq!(
+                    BigInt::abi_decode(encoded).unwrap(),
+                    BigInt::from_str("115792089237316195423570985008687907853269984665640564039457584007913129639935").unwrap(),
+                    "Decode Max Uint256"
+                );
+            }
+        }
+
+        #[test]
+        fn test_abi_decode_address() {
+            let encoded =
+                hex::decode("000000000000000000000000ca0e8f557ea98f950029a41d74f16dd76648b1f1")
+                    .unwrap();
+            assert_eq!(
+                Address::abi_decode(encoded).unwrap(),
+                Address::from_str("0xca0e8f557ea98f950029a41d74f16dd76648b1f1").unwrap(),
+                "Decode Padded Address",
+            )
+        }
+    }
+
+    mod storage {
+        use std::str::FromStr;
+
+        use substreams::{scalar::BigInt, Hex};
+
+        use super::super::*;
+        use crate::{hex::Hexable, storage::Mapping};
+
+        #[test]
+        fn test_mapping_address_key() {
+            let m = Mapping {
+                slot: BigInt::from(12),
+            };
+            let preimage = Hex::decode("0000000000000000000000001a13f4ca1d028320a707d99520abfefca3998b7f000000000000000000000000000000000000000000000000000000000000000c").unwrap();
+            let encoded = "0x9e3150b55a3c0fe6929063dde4bd380cd1b3bd4bd4fca20b85691cb17e2880da";
+            let key = Address::from_str("0x1a13f4ca1d028320a707d99520abfefca3998b7f").unwrap();
+
+            assert_eq!(m.preimage(&key).to_hex(), preimage.to_hex());
+            assert_eq!(m.storage_key(&key).to_hex(), encoded);
+            assert_eq!(
+                m.key_from_preimage::<Address>(preimage).unwrap().to_hex(),
+                key.to_hex()
+            );
+        }
+
+        #[test]
+        fn test_mapping_big_int_key() {
+            let m = Mapping {
+                slot: BigInt::from(12),
+            };
+            let preimage = Hex::decode("000000000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000c").unwrap();
+            let encoded = "0x20e322d575d78a86a3761da49565fbbf1fcb4f0a86011c98ac148d9ee6b9c682";
+            let key = BigInt::from(127);
+
+            assert_eq!(m.preimage(&key).to_hex(), preimage.to_hex());
+            assert_eq!(m.storage_key(&key).to_hex(), encoded);
+            assert_eq!(m.key_from_preimage::<BigInt>(preimage).unwrap(), key);
+        }
+    }
+}


### PR DESCRIPTION
> **NOTE:** This PR is opened against the `eth-supply` branch because of some dependencies from it. I think it is easier to review this changes in isolation than if everything was mixed.

### Summary 

This PR adds a few utilities for dealing with events and storage changes.

### Events
In subgraphs, handling an event is as simple as writing a function that takes the event as an argument. Here in substreams, so far what we've been doing is to reimplement over and over all the iterating over the logs in the block and matching their signature with our ABI event.

I've added a very simple class (can you call them classes in rust?) to handle all that. The usage is documented in the code, but it is something like:
```
let mut some_handler = |ev: SomeEvent, tx: &TransactionTrace, log: &Log| { /*...*/ };

let eh = EventHandler::new(&block);
eh.on::<SomeEvent, _>(some_handler);
eh.handle_events();
``` 

### Storage Changes
On top of that, I've had to work with `storage_changes`. Working with them is also very raw at the moment, it involves abi_encoding types, hashing stuff and things like that. I started a very naive set of utilities to work with that. Its purpose, more than being usable, is to have us add to that instead of implementing our own logic on each individual substream every time.



