### PR TITLE
Added substreams config for all repo deployments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Validate Substreams Params Schema
         run: cd config && npm run validate:params
 
+      - name: Validate Subgraph Deployments
+        run: cd config && npm run validate:subgraphs
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,30 @@ on:
     branches:
       - master
 jobs:
+  validate-params:
+    name: ValidateSubstreamsParams
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('./config/package-lock.json') }}
+          restore-keys: npm-
+
+      - name: Install dependencies
+        run: cd config && npm ci --ignore-scripts
+
+      - name: Validate Substreams Params Schema
+        run: cd config && npm run validate:params
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -24,10 +48,10 @@ jobs:
       - name: install rust-toolchain
         uses: actions-rs/toolchain@v1.0.6
         with:
-            toolchain: stable
-            target: wasm32-unknown-unknown
-            override: true
-            components: rustfmt, clippy
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+          components: rustfmt, clippy
       - name: run cargo fmt check
         uses: actions-rs/cargo@v1
         with:

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/config/package-lock.json
+++ b/config/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "config",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "config",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "json-schema": "^0.4.0",
+        "jsonschema": "^1.4.1"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "node_modules/jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "engines": {
+        "node": "*"
+      }
+    }
+  },
+  "dependencies": {
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ=="
+    }
+  }
+}

--- a/config/package.json
+++ b/config/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "config",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "validate:params": "node validate-params-schema.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "json-schema": "^0.4.0",
+    "jsonschema": "^1.4.1"
+  }
+}

--- a/config/package.json
+++ b/config/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "validate:params": "node validate-params-schema.js"
+    "validate:params": "node validate-params-schema.js",
+    "validate:subgraphs": "node validate-subgraphs-schema.js"
   },
   "author": "",
   "license": "ISC",

--- a/config/params.json
+++ b/config/params.json
@@ -1,0 +1,73 @@
+[
+  {
+    "name": "aave-v2",
+    "path": "../aave-v2",
+    "outputModules": ["map_output"],
+    "subgraphModule": "map_entity_changes",
+    "deployments": [
+      {
+        "name": "aave-v2-ethereum",
+        "network": "mainnet",
+        "params": {
+          "store_observed_contracts": "0x357d51124f59836ded84c8a1730d72b749d8bc23;0x8dff5e27ea6b7ac08ebfdf9eb090f32ee9a30fcf;0x26db2b833021583566323e3b8985999981b9f1f3"
+        },
+        "startBlocks": {
+          "store_observed_contracts": 12486774,
+          "map_atoken_supply_changes": 12486774,
+          "map_atoken_balances": 12486774,
+          "map_raw_events": 12486774,
+          "map_output": 12486774
+        }
+      },
+      {
+        "name": "aave-v2-polygon",
+        "network": "polygon",
+        "params": {
+          "store_observed_contracts": "0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9;0x311bb771e4f8952e6da169b425e7e92d6ac45756;0xd784927ff2f95ba542bfc824c8a8a98f3495f6b5"
+        },
+        "startBlocks": {
+          "store_observed_contracts": 11362579,
+          "map_atoken_supply_changes": 11362579,
+          "map_atoken_balances": 11362579,
+          "map_raw_events": 11362579,
+          "map_output": 11362579
+        }
+      }
+    ]
+  },
+  {
+    "name": "eth-supply",
+    "path": "../eth-supply",
+    "outputModules": ["map_output", "map_supply_delta"],
+    "subgraphModule": "map_entity_changes",
+    "deployments": [
+      {
+        "name": "eth-supply-ethereum",
+        "network": "mainnet",
+        "params": {},
+        "startBlocks": {}
+      }
+    ]
+  },
+  {
+    "name": "synthetix",
+    "path": "../synthetix",
+    "outputModules": ["parquet_out"],
+    "subgraphModule": "graph_out",
+    "deployments": [
+      {
+        "name": "synthetix-ethereum",
+        "network": "mainnet",
+        "params": {},
+        "startBlocks": {
+          "map_snx_balances": 10042599,
+          "map_escrow_rewards": 7680399,
+          "store_balances": 10042599,
+          "map_liquidation_rewards": 14771402,
+          "parquet_out": 7680399,
+          "graph_out": 7680399
+        }
+      }
+    ]
+  }
+]

--- a/config/schemas/params.schema.json
+++ b/config/schemas/params.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://raw.githubusercontent.com/messari/substreams/master/config/schemas/params.schema.json",
+  "title": "Schema for the definition of substream parameters",
+  "description": "A given substream can potentially be run with multiple different inputs, networks, and start blocks. This schema defines how we define all the supported deployments for the substreams in this repository.",
+
+  "type": "array",
+  "items": {
+    "$ref": "#/$defs/substream"
+  },
+
+  "$defs": {
+    "substream": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "outputModules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subgraphModule": {
+          "type": "string"
+        },
+        "deployments": {
+          "$ref": "#/$defs/substreamDeployments"
+        }
+      },
+      "required": ["name", "path", "outputModules", "deployments"]
+    },
+
+    "substreamDeployment": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "network": {
+          "type": "string"
+        },
+        "params": {
+          "type": "object"
+        },
+        "startBlocks": {
+          "type": "object"
+        }
+      },
+      "required": ["name", "network", "startBlocks"]
+    },
+
+    "substreamDeployments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/substreamDeployment"
+      }
+    }
+  }
+}

--- a/config/schemas/subgraphs.schema.json
+++ b/config/schemas/subgraphs.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://raw.githubusercontent.com/messari/substreams/master/config/schemas/subgraphs.schema.json",
+  "title": "Schema for the substream powered subgraphs deployment registry",
+  "description": "All substreams that we deploy as subgraphs, both to the hosted service and network should be reflected in subgraphs.json, following the schema in this file.",
+
+  "type": "object",
+  "additionalProperties": {
+    "$ref": "#/$defs/subgraph"
+  },
+
+  "$defs": {
+    "subgraph": {
+      "properties": {
+        "services": {
+          "type": "object",
+          "properties": {
+            "hosted-service": {
+              "$ref": "#/$defs/service"
+            },
+            "decentralized-network": {
+              "$ref": "#/$defs/service"
+            },
+            "anyOf": [
+              { "required": ["hosted-service"] },
+              { "required": ["decentralized-network"] }
+            ]
+          }
+        }
+      },
+      "required": ["services"]
+    },
+
+    "service": {
+      "type": "object",
+      "properties": {
+        "slug": {
+          "type": "string"
+        },
+        "query-id": {
+          "type": "string"
+        }
+      },
+      "required": ["slug", "query-id"]
+    }
+  }
+}

--- a/config/subgraphs.json
+++ b/config/subgraphs.json
@@ -1,0 +1,18 @@
+{
+  "eth-supply/eth-supply-ethereum": {
+    "services": {
+      "hosted-service": {
+        "slug": "substream-eth-supply-ethereum",
+        "query-id": "substream-eth-supply-ethereum"
+      }
+    }
+  },
+  "synthetix/synthetix-ethereum": {
+    "services": {
+      "hosted-service": {
+        "slug": "substream-snx-balance-ethereum",
+        "query-id": "substream-snx-balance-ethereum"
+      }
+    }
+  }
+}

--- a/config/validate-params-schema.js
+++ b/config/validate-params-schema.js
@@ -1,0 +1,16 @@
+const Validator = require('jsonschema').Validator;
+const paramsSchema = require('./schemas/params.schema.json');
+const params = require('./params');
+
+(() => {
+    var v = new Validator();
+    const res = v.validate(params, paramsSchema)
+
+    if (res.valid) {
+        console.info("Params Schema OK!")
+        return;
+    }
+
+    console.error('Invalid params.json file', res.errors);
+    throw new Error('Invalid params.json file');
+})();

--- a/config/validate-subgraphs-schema.js
+++ b/config/validate-subgraphs-schema.js
@@ -1,0 +1,33 @@
+const Validator = require('jsonschema').Validator;
+const subgraphsSchema = require('./schemas/subgraphs.schema.json');
+const subgraphs = require('./subgraphs');
+const substreams = require('./params');
+
+(() => {
+    var v = new Validator();
+    const res = v.validate(subgraphs, subgraphsSchema)
+
+    if (!res.valid) {
+        console.error('Invalid subgraphs.json file', res.errors);
+        throw new Error('Invalid subgraphs.json file');
+    }
+
+    validateSubgraphSlugs(subgraphs, substreams);
+    console.info("Subgraphs Schema OK!")
+})();
+
+// subgraph slugs need to be of the form `{substream_name}/{deployment_name}`.
+function validateSubgraphSlugs(subgraphs, substreams) {
+    const substreamSlugs = {};
+    for (let substream of substreams) {
+        for (let deployment of substream.deployments) {
+            substreamSlugs[`${substream.name}/${deployment.name}`] = true;
+        }
+    }
+
+    for (let slug in subgraphs) {
+        if (!substreamSlugs[slug]) {
+            throw new Error(`Invalid subgraph slug ${slug}. It should be of the form {substream_name}/{deployment_name} for an existing substream and deployment.`);
+        }
+    }
+}


### PR DESCRIPTION

Every substream we build will potentially be reused with different params. For example, a substream built for uniswap v2 can be reused for other deployments of uniswap in other networks just by changing the contract addresses where we are listening on, the start blocks, and the network names.

This PR defines a schema for how we should configure our substreams. It allows to arbitrarily change the params passed to any given module, the start blocks each module start running at, and defines which modules output the relevant data we want to obtain from the substream.

Since the moment this is merged to master, every substream that is intended to be deployed in any way (via a subgraph, or standalone through some sink), should add all its deployment configuration variants to this file.

This will be the starting point to then automate subgraph (re)deployments, and standalone substream deployments.